### PR TITLE
rewrite CameraController.java to work with both camera1 and camera2

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/camera/Camera1Controller.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/camera/Camera1Controller.java
@@ -1,0 +1,772 @@
+/*
+ * This is the source code of Telegram for Android v. 5.x.x.
+ * It is licensed under GNU GPL v. 2 or later.
+ * You should have received a copy of the license in this archive (see LICENSE).
+ *
+ * Copyright Nikolai Kudashov, 2013-2018.
+ */
+
+package org.telegram.messenger.camera;
+
+import android.content.SharedPreferences;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.Matrix;
+import android.graphics.SurfaceTexture;
+import android.graphics.drawable.BitmapDrawable;
+import android.hardware.Camera;
+import android.media.MediaMetadataRetriever;
+import android.media.MediaRecorder;
+import android.os.Build;
+import android.provider.MediaStore;
+import android.util.Base64;
+
+import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.ApplicationLoader;
+import org.telegram.messenger.Bitmaps;
+import org.telegram.messenger.BuildVars;
+import org.telegram.messenger.FileLoader;
+import org.telegram.messenger.FileLog;
+import org.telegram.messenger.ImageLoader;
+import org.telegram.messenger.MessagesController;
+import org.telegram.messenger.NotificationCenter;
+import org.telegram.messenger.SendMessagesHelper;
+import org.telegram.messenger.SharedConfig;
+import org.telegram.messenger.Utilities;
+import org.telegram.tgnet.SerializedData;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class Camera1Controller implements MediaRecorder.OnInfoListener, ICameraController {
+
+    private static final int CORE_POOL_SIZE = 1;
+    private static final int MAX_POOL_SIZE = 1;
+    private static final int KEEP_ALIVE_SECONDS = 60;
+
+    private ThreadPoolExecutor threadPool;
+
+    private MediaRecorder recorder;
+    private String recordedFile;
+    private boolean mirrorRecorderVideo;
+    protected volatile ArrayList<CameraInfo> cameraInfos;
+    private CameraController.VideoTakeCallback onVideoTakeCallback;
+    private boolean cameraInitied;
+    private boolean loadingCameras;
+
+    private ArrayList<Runnable> onFinishCameraInitRunnables = new ArrayList<>();
+
+    public Camera1Controller() {
+        threadPool = new ThreadPoolExecutor(CORE_POOL_SIZE, MAX_POOL_SIZE, KEEP_ALIVE_SECONDS, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+    }
+
+    @Override
+    public void cancelOnInitRunnable(final Runnable onInitRunnable) {
+        onFinishCameraInitRunnables.remove(onInitRunnable);
+    }
+
+    @Override
+    public void initCamera(final Runnable onInitRunnable) {
+        initCamera(onInitRunnable, false);
+    }
+
+    private void initCamera(final Runnable onInitRunnable, boolean withDelay) {
+        if (cameraInitied) {
+            return;
+        }
+        if (onInitRunnable != null && !onFinishCameraInitRunnables.contains(onInitRunnable)) {
+            onFinishCameraInitRunnables.add(onInitRunnable);
+        }
+        if (loadingCameras || cameraInitied) {
+            return;
+        }
+        loadingCameras = true;
+        threadPool.execute(() -> {
+            try {
+                if (cameraInfos == null) {
+                    SharedPreferences preferences = MessagesController.getGlobalMainSettings();
+                    String cache = preferences.getString("cameraCache", null);
+                    Comparator<Size> comparator = (o1, o2) -> {
+                        if (o1.mWidth < o2.mWidth) {
+                            return 1;
+                        } else if (o1.mWidth > o2.mWidth) {
+                            return -1;
+                        } else {
+                            if (o1.mHeight < o2.mHeight) {
+                                return 1;
+                            } else if (o1.mHeight > o2.mHeight) {
+                                return -1;
+                            }
+                            return 0;
+                        }
+                    };
+                    ArrayList<CameraInfo> result = new ArrayList<>();
+                    if (cache != null) {
+                        SerializedData serializedData = new SerializedData(Base64.decode(cache, Base64.DEFAULT));
+                        int count = serializedData.readInt32(false);
+                        for (int a = 0; a < count; a++) {
+                            CameraInfo cameraInfo = new CameraInfo(serializedData.readInt32(false), serializedData.readInt32(false));
+                            int pCount = serializedData.readInt32(false);
+                            for (int b = 0; b < pCount; b++) {
+                                cameraInfo.previewSizes.add(new Size(serializedData.readInt32(false), serializedData.readInt32(false)));
+                            }
+                            pCount = serializedData.readInt32(false);
+                            for (int b = 0; b < pCount; b++) {
+                                cameraInfo.pictureSizes.add(new Size(serializedData.readInt32(false), serializedData.readInt32(false)));
+                            }
+                            result.add(cameraInfo);
+
+                            Collections.sort(cameraInfo.previewSizes, comparator);
+                            Collections.sort(cameraInfo.pictureSizes, comparator);
+                        }
+                        serializedData.cleanup();
+                    } else {
+                        int count = Camera.getNumberOfCameras();
+                        Camera.CameraInfo info = new Camera.CameraInfo();
+
+                        int bufferSize = 4;
+                        for (int cameraId = 0; cameraId < count; cameraId++) {
+                            Camera.getCameraInfo(cameraId, info);
+                            CameraInfo cameraInfo = new CameraInfo(cameraId, info.facing);
+
+                            if (ApplicationLoader.mainInterfacePaused && ApplicationLoader.externalInterfacePaused) {
+                                throw new RuntimeException("APP_PAUSED");
+                            }
+                            Camera camera = Camera.open(cameraInfo.getCameraId());
+                            Camera.Parameters params = camera.getParameters();
+
+                            List<Camera.Size> list = params.getSupportedPreviewSizes();
+                            for (int a = 0; a < list.size(); a++) {
+                                Camera.Size size = list.get(a);
+                                if (size.width == 1280 && size.height != 720) {
+                                    continue;
+                                }
+                                if (size.height < 2160 && size.width < 2160) {
+                                    cameraInfo.previewSizes.add(new Size(size.width, size.height));
+                                    if (BuildVars.LOGS_ENABLED) {
+                                        FileLog.d("preview size = " + size.width + " " + size.height);
+                                    }
+                                }
+                            }
+
+                            list = params.getSupportedPictureSizes();
+                            for (int a = 0; a < list.size(); a++) {
+                                Camera.Size size = list.get(a);
+                                if (size.width == 1280 && size.height != 720) {
+                                    continue;
+                                }
+                                if (!"samsung".equals(Build.MANUFACTURER) || !"jflteuc".equals(Build.PRODUCT) || size.width < 2048) {
+                                    cameraInfo.pictureSizes.add(new Size(size.width, size.height));
+                                    if (BuildVars.LOGS_ENABLED) {
+                                        FileLog.d("picture size = " + size.width + " " + size.height);
+                                    }
+                                }
+                            }
+
+                            camera.release();
+                            result.add(cameraInfo);
+
+                            Collections.sort(cameraInfo.previewSizes, comparator);
+                            Collections.sort(cameraInfo.pictureSizes, comparator);
+
+                            bufferSize += 4 + 4 + 8 * (cameraInfo.previewSizes.size() + cameraInfo.pictureSizes.size());
+                        }
+
+                        SerializedData serializedData = new SerializedData(bufferSize);
+                        serializedData.writeInt32(result.size());
+                        for (int a = 0; a < count; a++) {
+                            CameraInfo cameraInfo = result.get(a);
+                            serializedData.writeInt32(cameraInfo.cameraId);
+                            serializedData.writeInt32(cameraInfo.frontCamera);
+
+                            int pCount = cameraInfo.previewSizes.size();
+                            serializedData.writeInt32(pCount);
+                            for (int b = 0; b < pCount; b++) {
+                                Size size = cameraInfo.previewSizes.get(b);
+                                serializedData.writeInt32(size.mWidth);
+                                serializedData.writeInt32(size.mHeight);
+                            }
+                            pCount = cameraInfo.pictureSizes.size();
+                            serializedData.writeInt32(pCount);
+                            for (int b = 0; b < pCount; b++) {
+                                Size size = cameraInfo.pictureSizes.get(b);
+                                serializedData.writeInt32(size.mWidth);
+                                serializedData.writeInt32(size.mHeight);
+                            }
+                        }
+                        preferences.edit().putString("cameraCache", Base64.encodeToString(serializedData.toByteArray(), Base64.DEFAULT)).commit();
+                        serializedData.cleanup();
+                    }
+                    cameraInfos = result;
+                }
+                AndroidUtilities.runOnUIThread(() -> {
+                    loadingCameras = false;
+                    cameraInitied = true;
+                    if (!onFinishCameraInitRunnables.isEmpty()) {
+                        for (int a = 0; a < onFinishCameraInitRunnables.size(); a++) {
+                            onFinishCameraInitRunnables.get(a).run();
+                        }
+                        onFinishCameraInitRunnables.clear();
+                    }
+                    NotificationCenter.getGlobalInstance().postNotificationName(NotificationCenter.cameraInitied);
+                });
+            } catch (Exception e) {
+                AndroidUtilities.runOnUIThread(() -> {
+                    onFinishCameraInitRunnables.clear();
+                    loadingCameras = false;
+                    cameraInitied = false;
+                    if (!withDelay && "APP_PAUSED".equals(e.getMessage())) {
+                        AndroidUtilities.runOnUIThread(() -> initCamera(onInitRunnable, true), 1000);
+                    }
+                });
+            }
+        });
+    }
+
+    @Override
+    public boolean isCameraInitied() {
+        return cameraInitied && cameraInfos != null && !cameraInfos.isEmpty();
+    }
+
+    @Override
+    public void close(final CameraSession session, final CountDownLatch countDownLatch, final Runnable beforeDestroyRunnable) {
+        session.destroy();
+        threadPool.execute(() -> {
+            if (beforeDestroyRunnable != null) {
+                beforeDestroyRunnable.run();
+            }
+            if (session.cameraInfo.camera != null) {
+                try {
+                    session.cameraInfo.camera.stopPreview();
+                    session.cameraInfo.camera.setPreviewCallbackWithBuffer(null);
+                } catch (Exception e) {
+                    FileLog.e(e);
+                }
+                try {
+                    session.cameraInfo.camera.release();
+                } catch (Exception e) {
+                    FileLog.e(e);
+                }
+                session.cameraInfo.camera = null;
+            }
+            if (countDownLatch != null) {
+                countDownLatch.countDown();
+            }
+        });
+        if (countDownLatch != null) {
+            try {
+                countDownLatch.await();
+            } catch (Exception e) {
+                FileLog.e(e);
+            }
+        }
+    }
+
+    @Override
+    public ArrayList<CameraInfo> getCameras() {
+        return cameraInfos;
+    }
+
+    private static int getOrientation(byte[] jpeg) {
+        if (jpeg == null) {
+            return 0;
+        }
+
+        int offset = 0;
+        int length = 0;
+
+        while (offset + 3 < jpeg.length && (jpeg[offset++] & 0xFF) == 0xFF) {
+            int marker = jpeg[offset] & 0xFF;
+
+            if (marker == 0xFF) {
+                continue;
+            }
+            offset++;
+
+            if (marker == 0xD8 || marker == 0x01) {
+                continue;
+            }
+            if (marker == 0xD9 || marker == 0xDA) {
+                break;
+            }
+
+            length = pack(jpeg, offset, 2, false);
+            if (length < 2 || offset + length > jpeg.length) {
+                return 0;
+            }
+
+            // Break if the marker is EXIF in APP1.
+            if (marker == 0xE1 && length >= 8 &&
+                pack(jpeg, offset + 2, 4, false) == 0x45786966 &&
+                pack(jpeg, offset + 6, 2, false) == 0) {
+                offset += 8;
+                length -= 8;
+                break;
+            }
+
+            offset += length;
+            length = 0;
+        }
+
+        if (length > 8) {
+            int tag = pack(jpeg, offset, 4, false);
+            if (tag != 0x49492A00 && tag != 0x4D4D002A) {
+                return 0;
+            }
+            boolean littleEndian = (tag == 0x49492A00);
+
+            int count = pack(jpeg, offset + 4, 4, littleEndian) + 2;
+            if (count < 10 || count > length) {
+                return 0;
+            }
+            offset += count;
+            length -= count;
+
+            count = pack(jpeg, offset - 2, 2, littleEndian);
+            while (count-- > 0 && length >= 12) {
+                tag = pack(jpeg, offset, 2, littleEndian);
+                if (tag == 0x0112) {
+                    int orientation = pack(jpeg, offset + 8, 2, littleEndian);
+                    switch (orientation) {
+                        case 1:
+                            return 0;
+                        case 3:
+                            return 180;
+                        case 6:
+                            return 90;
+                        case 8:
+                            return 270;
+                    }
+                    return 0;
+                }
+                offset += 12;
+                length -= 12;
+            }
+        }
+        return 0;
+    }
+
+    private static int pack(byte[] bytes, int offset, int length, boolean littleEndian) {
+        int step = 1;
+        if (littleEndian) {
+            offset += length - 1;
+            step = -1;
+        }
+
+        int value = 0;
+        while (length-- > 0) {
+            value = (value << 8) | (bytes[offset] & 0xFF);
+            offset += step;
+        }
+        return value;
+    }
+
+    @Override
+    public boolean takePicture(final File path, final CameraSession session, final Runnable callback) {
+        if (session == null) {
+            return false;
+        }
+        final CameraInfo info = session.cameraInfo;
+        final boolean flipFront = session.isFlipFront();
+        Camera camera = info.camera;
+        try {
+            camera.takePicture(null, null, (data, camera1) -> {
+                Bitmap bitmap = null;
+                int size = (int) (AndroidUtilities.getPhotoSize() / AndroidUtilities.density);
+                String key = String.format(Locale.US, "%s@%d_%d", Utilities.MD5(path.getAbsolutePath()), size, size);
+                try {
+                    BitmapFactory.Options options = new BitmapFactory.Options();
+                    options.inJustDecodeBounds = true;
+                    BitmapFactory.decodeByteArray(data, 0, data.length, options);
+                    float scaleFactor = Math.max((float) options.outWidth / AndroidUtilities.getPhotoSize(), (float) options.outHeight / AndroidUtilities.getPhotoSize());
+                    if (scaleFactor < 1) {
+                        scaleFactor = 1;
+                    }
+                    options.inJustDecodeBounds = false;
+                    options.inSampleSize = (int) scaleFactor;
+                    options.inPurgeable = true;
+                    bitmap = BitmapFactory.decodeByteArray(data, 0, data.length, options);
+                } catch (Throwable e) {
+                    FileLog.e(e);
+                }
+                try {
+                    if (info.frontCamera != 0 && flipFront) {
+                        try {
+                            Matrix matrix = new Matrix();
+                            matrix.setRotate(getOrientation(data));
+                            matrix.postScale(-1, 1);
+                            Bitmap scaled = Bitmaps.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+                            if (scaled != bitmap) {
+                                bitmap.recycle();
+                            }
+                            FileOutputStream outputStream = new FileOutputStream(path);
+                            scaled.compress(Bitmap.CompressFormat.JPEG, 80, outputStream);
+                            outputStream.flush();
+                            outputStream.getFD().sync();
+                            outputStream.close();
+                            if (scaled != null) {
+                                ImageLoader.getInstance().putImageToCache(new BitmapDrawable(scaled), key);
+                            }
+                            if (callback != null) {
+                                callback.run();
+                            }
+                            return;
+                        } catch (Throwable e) {
+                            FileLog.e(e);
+                        }
+                    }
+                    FileOutputStream outputStream = new FileOutputStream(path);
+                    outputStream.write(data);
+                    outputStream.flush();
+                    outputStream.getFD().sync();
+                    outputStream.close();
+                    if (bitmap != null) {
+                        ImageLoader.getInstance().putImageToCache(new BitmapDrawable(bitmap), key);
+                    }
+                } catch (Exception e) {
+                    FileLog.e(e);
+                }
+                if (callback != null) {
+                    callback.run();
+                }
+            });
+            return true;
+        } catch (Exception e) {
+            FileLog.e(e);
+        }
+        return false;
+    }
+
+    @Override
+    public void startPreview(final CameraSession session) {
+        if (session == null) {
+            return;
+        }
+        threadPool.execute(() -> {
+            Camera camera = session.cameraInfo.camera;
+            try {
+                if (camera == null) {
+                    camera = session.cameraInfo.camera = Camera.open(session.cameraInfo.cameraId);
+                }
+                camera.startPreview();
+            } catch (Exception e) {
+                session.cameraInfo.camera = null;
+                if (camera != null) {
+                    camera.release();
+                }
+                FileLog.e(e);
+            }
+        });
+    }
+
+    @Override
+    public void stopPreview(final CameraSession session) {
+        if (session == null) {
+            return;
+        }
+        threadPool.execute(() -> {
+            Camera camera = session.cameraInfo.camera;
+            try {
+                if (camera == null) {
+                    camera = session.cameraInfo.camera = Camera.open(session.cameraInfo.cameraId);
+                }
+                camera.stopPreview();
+            } catch (Exception e) {
+                session.cameraInfo.camera = null;
+                if (camera != null) {
+                    camera.release();
+                }
+                FileLog.e(e);
+            }
+        });
+    }
+
+    @Override
+    public void openRound(final CameraSession session, final SurfaceTexture texture, final Runnable callback, final Runnable configureCallback) {
+        if (session == null || texture == null) {
+            if (BuildVars.LOGS_ENABLED) {
+                FileLog.d("failed to open round " + session + " tex = " + texture);
+            }
+            return;
+        }
+        threadPool.execute(() -> {
+            Camera camera = session.cameraInfo.camera;
+            try {
+                if (BuildVars.LOGS_ENABLED) {
+                    FileLog.d("start creating round camera session");
+                }
+                if (camera == null) {
+                    camera = session.cameraInfo.camera = Camera.open(session.cameraInfo.cameraId);
+                }
+                Camera.Parameters params = camera.getParameters();
+
+                session.configureRoundCamera();
+                if (configureCallback != null) {
+                    configureCallback.run();
+                }
+                camera.setPreviewTexture(texture);
+                camera.startPreview();
+                if (callback != null) {
+                    AndroidUtilities.runOnUIThread(callback);
+                }
+                if (BuildVars.LOGS_ENABLED) {
+                    FileLog.d("round camera session created");
+                }
+            } catch (Exception e) {
+                session.cameraInfo.camera = null;
+                if (camera != null) {
+                    camera.release();
+                }
+                FileLog.e(e);
+            }
+        });
+    }
+
+    @Override
+    public void open(final CameraSession session, final SurfaceTexture texture, final Runnable callback, final Runnable prestartCallback) {
+        if (session == null || texture == null) {
+            return;
+        }
+        threadPool.execute(() -> {
+            Camera camera = session.cameraInfo.camera;
+            try {
+                if (camera == null) {
+                    camera = session.cameraInfo.camera = Camera.open(session.cameraInfo.cameraId);
+                }
+                Camera.Parameters params = camera.getParameters();
+                List<String> rawFlashModes = params.getSupportedFlashModes();
+
+                availableFlashModes.clear();
+                if (rawFlashModes != null) {
+                    for (int a = 0; a < rawFlashModes.size(); a++) {
+                        String rawFlashMode = rawFlashModes.get(a);
+                        if (rawFlashMode.equals(Camera.Parameters.FLASH_MODE_OFF) || rawFlashMode.equals(Camera.Parameters.FLASH_MODE_ON) || rawFlashMode.equals(Camera.Parameters.FLASH_MODE_AUTO)) {
+                            availableFlashModes.add(rawFlashMode);
+                        }
+                    }
+                    session.checkFlashMode(availableFlashModes.get(0));
+                }
+
+                if (prestartCallback != null) {
+                    prestartCallback.run();
+                }
+
+                session.configurePhotoCamera();
+                camera.setPreviewTexture(texture);
+                camera.startPreview();
+                if (callback != null) {
+                    AndroidUtilities.runOnUIThread(callback);
+                }
+            } catch (Exception e) {
+                session.cameraInfo.camera = null;
+                if (camera != null) {
+                    camera.release();
+                }
+                FileLog.e(e);
+            }
+        });
+    }
+
+    @Override
+    public void recordVideo(final CameraSession session, final File path, boolean mirror, final CameraController.VideoTakeCallback callback, final Runnable onVideoStartRecord) {
+        if (session == null) {
+            return;
+        }
+
+        final CameraInfo info = session.cameraInfo;
+        final Camera camera = info.camera;
+        threadPool.execute(() -> {
+            try {
+                if (camera != null) {
+                    try {
+                        Camera.Parameters params = camera.getParameters();
+                        params.setFlashMode(session.getCurrentFlashMode().equals(Camera.Parameters.FLASH_MODE_ON) ? Camera.Parameters.FLASH_MODE_TORCH : Camera.Parameters.FLASH_MODE_OFF);
+                        camera.setParameters(params);
+                    } catch (Exception e) {
+                        FileLog.e(e);
+                    }
+                    camera.unlock();
+                    //camera.stopPreview();
+                    try {
+                        mirrorRecorderVideo = mirror;
+                        recorder = new MediaRecorder();
+                        recorder.setCamera(camera);
+                        recorder.setVideoSource(MediaRecorder.VideoSource.CAMERA);
+                        recorder.setAudioSource(MediaRecorder.AudioSource.CAMCORDER);
+                        session.configureRecorder(1, recorder);
+                        recorder.setOutputFile(path.getAbsolutePath());
+                        recorder.setMaxFileSize(1024 * 1024 * 1024);
+                        recorder.setVideoFrameRate(30);
+                        recorder.setMaxDuration(0);
+                        Size pictureSize;
+                        pictureSize = new Size(16, 9);
+                        pictureSize = CameraController.chooseOptimalSize(info.getPictureSizes(), 720, 480, pictureSize);
+                        int bitrate;
+                        if (Math.min(pictureSize.mHeight,pictureSize.mWidth) >= 720) {
+                            bitrate = 3500000;
+                        } else {
+                            bitrate = 1800000;
+                        }
+                        recorder.setVideoEncodingBitRate(bitrate);
+                        recorder.setVideoSize(pictureSize.getWidth(), pictureSize.getHeight());
+                        recorder.setOnInfoListener(Camera1Controller.this);
+                        recorder.prepare();
+                        recorder.start();
+
+                        onVideoTakeCallback = callback;
+                        recordedFile = path.getAbsolutePath();
+                        if (onVideoStartRecord != null) {
+                            AndroidUtilities.runOnUIThread(onVideoStartRecord);
+                        }
+                    } catch (Exception e) {
+                        recorder.release();
+                        recorder = null;
+                        FileLog.e(e);
+                    }
+                }
+            } catch (Exception e) {
+                FileLog.e(e);
+            }
+        });
+    }
+
+    private void finishRecordingVideo() {
+        MediaMetadataRetriever mediaMetadataRetriever = null;
+        long duration = 0;
+        try {
+            mediaMetadataRetriever = new MediaMetadataRetriever();
+            mediaMetadataRetriever.setDataSource(recordedFile);
+            String d = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
+            if (d != null) {
+                duration = (int) Math.ceil(Long.parseLong(d) / 1000.0f);
+            }
+        } catch (Exception e) {
+            FileLog.e(e);
+        } finally {
+            try {
+                if (mediaMetadataRetriever != null) {
+                    mediaMetadataRetriever.release();
+                }
+            } catch (Exception e) {
+                FileLog.e(e);
+            }
+        }
+        Bitmap bitmap = SendMessagesHelper.createVideoThumbnail(recordedFile, MediaStore.Video.Thumbnails.MINI_KIND);
+        if (mirrorRecorderVideo) {
+            Bitmap b = Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(b);
+            canvas.scale(-1, 1, b.getWidth() / 2, b.getHeight() / 2);
+            canvas.drawBitmap(bitmap, 0, 0, null);
+            bitmap.recycle();
+            bitmap = b;
+        }
+        String fileName = Integer.MIN_VALUE + "_" + SharedConfig.getLastLocalId() + ".jpg";
+        final File cacheFile = new File(FileLoader.getDirectory(FileLoader.MEDIA_DIR_CACHE), fileName);
+        try {
+            FileOutputStream stream = new FileOutputStream(cacheFile);
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 87, stream);
+        } catch (Throwable e) {
+            FileLog.e(e);
+        }
+        SharedConfig.saveConfig();
+        final long durationFinal = duration;
+        final Bitmap bitmapFinal = bitmap;
+        AndroidUtilities.runOnUIThread(() -> {
+            if (onVideoTakeCallback != null) {
+                String path = cacheFile.getAbsolutePath();
+                if (bitmapFinal != null) {
+                    ImageLoader.getInstance().putImageToCache(new BitmapDrawable(bitmapFinal), Utilities.MD5(path));
+                }
+                onVideoTakeCallback.onFinishVideoRecording(path, durationFinal);
+                onVideoTakeCallback = null;
+            }
+        });
+    }
+
+    @Override
+    public void onInfo(MediaRecorder mediaRecorder, int what, int extra) {
+        if (what == MediaRecorder.MEDIA_RECORDER_INFO_MAX_DURATION_REACHED || what == MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED || what == MediaRecorder.MEDIA_RECORDER_INFO_UNKNOWN) {
+            MediaRecorder tempRecorder = recorder;
+            recorder = null;
+            if (tempRecorder != null) {
+                tempRecorder.stop();
+                tempRecorder.release();
+            }
+            if (onVideoTakeCallback != null) {
+                finishRecordingVideo();
+            }
+        }
+    }
+
+    @Override
+    public void stopVideoRecording(final CameraSession session, final boolean abandon) {
+        threadPool.execute(() -> {
+            try {
+                CameraInfo info = session.cameraInfo;
+                final Camera camera = info.camera;
+                if (camera != null && recorder != null) {
+                    MediaRecorder tempRecorder = recorder;
+                    recorder = null;
+                    try {
+                        tempRecorder.stop();
+                    } catch (Exception e) {
+                        FileLog.e(e);
+                    }
+                    try {
+                        tempRecorder.release();
+                    } catch (Exception e) {
+                        FileLog.e(e);
+                    }
+                    try {
+                        camera.reconnect();
+                        camera.startPreview();
+                    } catch (Exception e) {
+                        FileLog.e(e);
+                    }
+                    try {
+                        session.stopVideoRecording();
+                    } catch (Exception e) {
+                        FileLog.e(e);
+                    }
+                }
+                try {
+                    Camera.Parameters params = camera.getParameters();
+                    params.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
+                    camera.setParameters(params);
+                } catch (Exception e) {
+                    FileLog.e(e);
+                }
+                threadPool.execute(() -> {
+                    try {
+                        Camera.Parameters params = camera.getParameters();
+                        params.setFlashMode(session.getCurrentFlashMode());
+                        camera.setParameters(params);
+                    } catch (Exception e) {
+                        FileLog.e(e);
+                    }
+                });
+                if (!abandon && onVideoTakeCallback != null) {
+                    finishRecordingVideo();
+                } else {
+                    onVideoTakeCallback = null;
+                }
+            } catch (Exception ignore) {
+            }
+        });
+    }
+
+    @Override
+    public void stopBackgroundThread() {
+        //nothing for camera1
+    }
+}

--- a/TMessagesProj/src/main/java/org/telegram/messenger/camera/Camera2Controller.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/camera/Camera2Controller.java
@@ -1,0 +1,795 @@
+package org.telegram.messenger.camera;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.ImageFormat;
+import android.graphics.Matrix;
+import android.graphics.SurfaceTexture;
+import android.graphics.drawable.BitmapDrawable;
+import android.hardware.camera2.CameraAccessException;
+import android.hardware.camera2.CameraCaptureSession;
+import android.hardware.camera2.CameraCharacteristics;
+import android.hardware.camera2.CameraDevice;
+import android.hardware.camera2.CameraManager;
+import android.hardware.camera2.CaptureRequest;
+import android.hardware.camera2.TotalCaptureResult;
+import android.hardware.camera2.params.StreamConfigurationMap;
+import android.media.Image;
+import android.media.ImageReader;
+import android.media.MediaMetadataRetriever;
+import android.media.MediaRecorder;
+import android.os.Build;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.provider.MediaStore;
+import android.view.Surface;
+import android.view.WindowManager;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.ApplicationLoader;
+import org.telegram.messenger.Bitmaps;
+import org.telegram.messenger.BuildVars;
+import org.telegram.messenger.FileLoader;
+import org.telegram.messenger.FileLog;
+import org.telegram.messenger.ImageLoader;
+import org.telegram.messenger.NotificationCenter;
+import org.telegram.messenger.SendMessagesHelper;
+import org.telegram.messenger.SharedConfig;
+import org.telegram.messenger.Utilities;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+public class Camera2Controller implements MediaRecorder.OnInfoListener, ICameraController {
+
+    private static final int CORE_POOL_SIZE = 1;
+    private static final int MAX_POOL_SIZE = 1;
+    private static final int KEEP_ALIVE_SECONDS = 60;
+    protected volatile ArrayList<CameraInfo> cameraInfos;
+    CameraService[] availableCameras = null;
+    private MediaRecorder recorder;
+    private final ThreadPoolExecutor threadPool;
+    private final CameraManager cameraManager;
+    private final ArrayList<Runnable> onFinishCameraInitRunnables = new ArrayList<>();
+    private boolean cameraInitied;
+    private boolean loadingCameras;
+    private CountDownLatch pictureReadyLatch = null;
+    private byte[] takePictureResult = null;
+    private boolean mirrorRecorderVideo;
+    private CameraController.VideoTakeCallback onVideoTakeCallback;
+
+    private HandlerThread backgroundThread;
+    private Handler backgroundHandler = null;
+    private String recordedFile;
+
+
+    public Camera2Controller() {
+        cameraManager = (CameraManager) ApplicationLoader.applicationContext.getSystemService(Context.CAMERA_SERVICE);
+        threadPool = new ThreadPoolExecutor(CORE_POOL_SIZE, MAX_POOL_SIZE, KEEP_ALIVE_SECONDS, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+    }
+
+    private void startBackgroundThread() {
+        backgroundThread = new HandlerThread("CameraBackground");
+        backgroundThread.start();
+        backgroundHandler = new Handler(backgroundThread.getLooper());
+    }
+
+    @Override
+    public void stopBackgroundThread() {
+        if (backgroundThread == null || backgroundHandler == null) return;
+        backgroundThread.quitSafely();
+        try {
+            backgroundThread.join();
+            backgroundThread = null;
+            backgroundHandler = null;
+        } catch (InterruptedException e) {
+            FileLog.d("camera2 stopBackgroundThread = " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void initCamera(Runnable onInitRunnable) {
+        initCamera(onInitRunnable, false);
+    }
+
+    private void initCamera(Runnable onInitRunnable, boolean withDelay) {
+        if (cameraInitied) {
+            if (backgroundThread == null || backgroundHandler == null) startBackgroundThread();
+            if (availableCameras.length >= 2) {
+                if (availableCameras[0] != null && availableCameras[0].backgroundHandler == null) {
+                    availableCameras[0].backgroundHandler = backgroundHandler;
+                }
+
+                if (availableCameras[1] != null && availableCameras[1].backgroundHandler == null) {
+                    availableCameras[1].backgroundHandler = backgroundHandler;
+                }
+            } else if (availableCameras.length == 1) {
+                if (availableCameras[0] != null && availableCameras[0].backgroundHandler == null) {
+                    availableCameras[0].backgroundHandler = backgroundHandler;
+                }
+            }
+            return;
+        }
+        if (onInitRunnable != null && !onFinishCameraInitRunnables.contains(onInitRunnable)) {
+            onFinishCameraInitRunnables.add(onInitRunnable);
+        }
+        if (loadingCameras || cameraInitied) {
+            return;
+        }
+        loadingCameras = true;
+
+        startBackgroundThread();
+
+        threadPool.execute(() -> {
+            try {
+                if (cameraInfos == null) {
+                    availableCameras = new CameraService[cameraManager.getCameraIdList().length];
+
+                    ArrayList<CameraInfo> result = new ArrayList<>();
+
+                    Comparator<Size> comparator = (o1, o2) -> {
+                        if (o1.mWidth < o2.mWidth) {
+                            return 1;
+                        } else if (o1.mWidth > o2.mWidth) {
+                            return -1;
+                        } else {
+                            if (o1.mHeight < o2.mHeight) {
+                                return 1;
+                            } else if (o1.mHeight > o2.mHeight) {
+                                return -1;
+                            }
+                            return 0;
+                        }
+                    };
+
+                    for (String cameraID : cameraManager.getCameraIdList()) {
+                        int id = Integer.parseInt(cameraID);
+                        CameraCharacteristics cameraCharacteristics = cameraManager.getCameraCharacteristics(cameraID);
+                        StreamConfigurationMap configurationMap = cameraCharacteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+                        int facing = cameraCharacteristics.get(CameraCharacteristics.LENS_FACING);
+
+                        // define proper rotation compensation for made photo
+                        int sensorOrientation = cameraCharacteristics.get(CameraCharacteristics.SENSOR_ORIENTATION);
+                        int polarity = facing == CameraCharacteristics.LENS_FACING_FRONT ? 1 : -1;
+                        WindowManager mgr = (WindowManager) ApplicationLoader.applicationContext.getSystemService(Context.WINDOW_SERVICE);
+                        int rotation = mgr.getDefaultDisplay().getRotation();
+                        long floorDivX = sensorOrientation + polarity * rotation;
+                        long floorDivY = 360;
+                        long floorDiv = floorDivX / floorDivY;
+                        if ((floorDivX ^ floorDivY) < 0 && (floorDiv * floorDivY != floorDivX)) {
+                            floorDiv--;
+                        }
+                        long floorMod = floorDivX - floorDiv * floorDivY;
+                        int rotationCompensation = (int) floorMod;
+
+                        if (ApplicationLoader.mainInterfacePaused && ApplicationLoader.externalInterfacePaused) {
+                            throw new RuntimeException("APP_PAUSED");
+                        }
+
+                        CameraInfo cameraInfo = new CameraInfo(id, facing == CameraCharacteristics.LENS_FACING_FRONT ? 1 : 0);
+
+                        android.util.Size[] list = configurationMap.getOutputSizes(ImageFormat.JPEG);
+                        for (int a = 0; a < list.length; a++) {
+                            android.util.Size size = list[a];
+
+                            if (size.getHeight() < 2160 && size.getWidth() < 2160) {
+                                cameraInfo.previewSizes.add(new Size(size.getWidth(), size.getHeight()));
+                                cameraInfo.pictureSizes.add(new Size(size.getWidth(), size.getHeight()));
+                                if (BuildVars.LOGS_ENABLED) {
+                                    FileLog.d("preview size = " + size.getWidth() + " " + size.getHeight());
+                                }
+                            }
+                        }
+
+                        result.add(cameraInfo);
+
+                        Collections.sort(cameraInfo.previewSizes, comparator);
+                        Collections.sort(cameraInfo.pictureSizes, comparator);
+
+
+                        result.add(cameraInfo);
+
+                        availableCameras[id] = new CameraService(cameraManager, cameraID, backgroundHandler, rotationCompensation);
+                    }
+
+                    cameraInfos = result;
+                }
+
+                AndroidUtilities.runOnUIThread(() -> {
+                    loadingCameras = false;
+                    cameraInitied = true;
+                    if (!onFinishCameraInitRunnables.isEmpty()) {
+                        for (int a = 0; a < onFinishCameraInitRunnables.size(); a++) {
+                            onFinishCameraInitRunnables.get(a).run();
+                        }
+                        onFinishCameraInitRunnables.clear();
+                    }
+                    NotificationCenter.getGlobalInstance().postNotificationName(NotificationCenter.cameraInitied);
+                });
+            } catch (Exception e) {
+                AndroidUtilities.runOnUIThread(() -> {
+                    onFinishCameraInitRunnables.clear();
+                    loadingCameras = false;
+                    cameraInitied = false;
+                    if (!withDelay && "APP_PAUSED".equals(e.getMessage())) {
+                        AndroidUtilities.runOnUIThread(() -> initCamera(onInitRunnable, true), 1000);
+                    }
+                });
+            }
+        });
+    }
+
+    @Override
+    public boolean isCameraInitied() {
+        return cameraInitied && cameraInfos != null && !cameraInfos.isEmpty();
+    }
+
+    @Override
+    public void close(CameraSession session, CountDownLatch countDownLatch, Runnable beforeDestroyRunnable) {
+        session.destroy();
+
+        threadPool.execute(() -> {
+            if (beforeDestroyRunnable != null) {
+                beforeDestroyRunnable.run();
+            }
+
+            availableCameras[session.cameraInfo.cameraId].closeCamera();
+
+            if (countDownLatch != null) {
+                countDownLatch.countDown();
+            }
+        });
+        if (countDownLatch != null) {
+            try {
+                countDownLatch.await();
+            } catch (Exception e) {
+                FileLog.e(e);
+            }
+        }
+    }
+
+    @Override
+    public boolean takePicture(File path, CameraSession session, Runnable callback) {
+        if (session == null) {
+            return false;
+        }
+
+        threadPool.execute(() -> {
+            pictureReadyLatch = new CountDownLatch(1);
+            takePictureResult = null;
+
+            availableCameras[session.cameraInfo.cameraId].makePhoto((photoBytes) -> {
+                takePictureResult = photoBytes;
+
+                if (pictureReadyLatch != null) {
+                    pictureReadyLatch.countDown();
+                }
+            });
+
+            if (pictureReadyLatch != null) {
+                try {
+                    pictureReadyLatch.await(3L, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    FileLog.e(e);
+                }
+            }
+
+            pictureReadyLatch = null;
+            availableCameras[session.cameraInfo.cameraId].clearCallback();
+
+            if (takePictureResult == null) return;
+
+            final CameraInfo info = session.cameraInfo;
+            final boolean flipFront = session.isFlipFront();
+            try {
+
+                Bitmap bitmap = null;
+                int size = (int) (AndroidUtilities.getPhotoSize() / AndroidUtilities.density);
+                String key = String.format(Locale.US, "%s@%d_%d", Utilities.MD5(path.getAbsolutePath()), size, size);
+                try {
+                    BitmapFactory.Options options = new BitmapFactory.Options();
+                    options.inJustDecodeBounds = true;
+                    BitmapFactory.decodeByteArray(takePictureResult, 0, takePictureResult.length, options);
+                    float scaleFactor = Math.max((float) options.outWidth / AndroidUtilities.getPhotoSize(), (float) options.outHeight / AndroidUtilities.getPhotoSize());
+                    if (scaleFactor < 1) {
+                        scaleFactor = 1;
+                    }
+                    options.inJustDecodeBounds = false;
+                    options.inSampleSize = (int) scaleFactor;
+                    options.inPurgeable = true;
+                    bitmap = BitmapFactory.decodeByteArray(takePictureResult, 0, takePictureResult.length, options);
+                } catch (Throwable e) {
+                    FileLog.e(e);
+                }
+                try {
+                    if (info.frontCamera != 0 && flipFront) {
+                        try {
+                            Matrix matrix = new Matrix();
+                            matrix.setRotate(availableCameras[session.cameraInfo.cameraId].rotationCompensation);
+                            matrix.postScale(-1, 1);
+                            Bitmap scaled = Bitmaps.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+                            if (scaled != bitmap) {
+                                bitmap.recycle();
+                            }
+                            FileOutputStream outputStream = new FileOutputStream(path);
+                            scaled.compress(Bitmap.CompressFormat.JPEG, 80, outputStream);
+                            outputStream.flush();
+                            outputStream.getFD().sync();
+                            outputStream.close();
+                            AndroidUtilities.runOnUIThread(() -> {
+                                if (scaled != null) {
+                                    ImageLoader.getInstance().putImageToCache(new BitmapDrawable(scaled), key);
+                                }
+                                if (callback != null) {
+                                    callback.run();
+                                }
+                            });
+                            return;
+                        } catch (Throwable e) {
+                            FileLog.e(e);
+                        }
+                    }
+                    Matrix matrix = new Matrix();
+                    matrix.setRotate(availableCameras[session.cameraInfo.cameraId].rotationCompensation);
+                    matrix.postScale(1, 1);
+                    Bitmap scaled = Bitmaps.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+                    if (scaled != bitmap) {
+                        bitmap.recycle();
+                    }
+                    FileOutputStream outputStream = new FileOutputStream(path);
+                    scaled.compress(Bitmap.CompressFormat.JPEG, 80, outputStream);
+                    outputStream.flush();
+                    outputStream.getFD().sync();
+                    outputStream.close();
+                    AndroidUtilities.runOnUIThread(() -> {
+                        if (scaled != null) {
+                            ImageLoader.getInstance().putImageToCache(new BitmapDrawable(scaled), key);
+                        }
+                    });
+                } catch (Exception e) {
+                    FileLog.e(e);
+                }
+                AndroidUtilities.runOnUIThread(() -> {
+                    if (callback != null) {
+                        callback.run();
+                    }
+                });
+            } catch (Exception e) {
+                FileLog.e(e);
+            }
+        });
+
+        return true;
+    }
+
+    @Override
+    public void startPreview(CameraSession session) {
+        if (session == null) {
+            return;
+        }
+        threadPool.execute(() -> {
+            availableCameras[session.cameraInfo.cameraId].relaunchPreview();
+        });
+    }
+
+    @Override
+    public void stopPreview(CameraSession session) {
+        if (session == null) {
+            return;
+        }
+        threadPool.execute(() -> {
+            availableCameras[session.cameraInfo.cameraId].stopPreview();
+        });
+    }
+
+    @SuppressLint("MissingPermission")
+    @Override
+    public void open(CameraSession session, SurfaceTexture texture, Runnable callback, Runnable prestartCallback) {
+        if (session == null || texture == null) {
+            return;
+        }
+
+        threadPool.execute(() -> {
+            availableCameras[session.cameraInfo.cameraId].openCamera(texture);
+
+            if (prestartCallback != null) {
+                prestartCallback.run();
+            }
+
+            if (callback != null) {
+                AndroidUtilities.runOnUIThread(callback);
+            }
+        });
+    }
+
+    @Override
+    public void openRound(CameraSession session, SurfaceTexture texture, Runnable callback, Runnable configureCallback) {
+
+        if (session == null || texture == null) {
+            if (BuildVars.LOGS_ENABLED) {
+                FileLog.d("failed to open round " + session + " tex = " + texture);
+            }
+            return;
+        }
+
+        threadPool.execute(() -> {
+            try {
+                if (BuildVars.LOGS_ENABLED) {
+                    FileLog.d("start creating round camera session");
+                }
+                availableCameras[session.cameraInfo.cameraId].openCamera(texture);
+
+                //session.configureRoundCamera();
+                if (configureCallback != null) {
+                    configureCallback.run();
+                }
+
+                if (callback != null) {
+                    AndroidUtilities.runOnUIThread(callback);
+                }
+                if (BuildVars.LOGS_ENABLED) {
+                    FileLog.d("round camera session created");
+                }
+            } catch (Exception e) {
+                FileLog.e(e);
+            }
+        });
+    }
+
+    @Override
+    public void recordVideo(final CameraSession session, final File path, boolean mirror, final CameraController.VideoTakeCallback callback, final Runnable onVideoStartRecord) {
+        if (session == null) {
+            return;
+        }
+
+        final CameraInfo info = session.cameraInfo;
+
+        threadPool.execute(() -> {
+            try {
+                mirrorRecorderVideo = mirror;
+                recorder = new MediaRecorder();
+                recorder.setVideoSource(MediaRecorder.VideoSource.SURFACE);
+                recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
+                session.configureRecorder(1, recorder);
+                recorder.setOutputFile(path.getAbsolutePath());
+                recorder.setMaxFileSize(1024 * 1024 * 1024);
+                recorder.setVideoFrameRate(30);
+                recorder.setMaxDuration(0);
+                Size pictureSize;
+                pictureSize = new Size(16, 9);
+                pictureSize = CameraController.chooseOptimalSize(info.getPictureSizes(), 720, 480, pictureSize);
+                int bitrate;
+                if (Math.min(pictureSize.mHeight, pictureSize.mWidth) >= 720) {
+                    bitrate = 3500000;
+                } else {
+                    bitrate = 1800000;
+                }
+                recorder.setVideoEncodingBitRate(bitrate);
+                recorder.setVideoSize(pictureSize.getWidth(), pictureSize.getHeight());
+                recorder.setOnInfoListener(Camera2Controller.this);
+
+                recorder.prepare();
+                availableCameras[session.cameraInfo.cameraId].recordVideo(recorder);
+                recorder.start();
+
+                onVideoTakeCallback = callback;
+                recordedFile = path.getAbsolutePath();
+                if (onVideoStartRecord != null) {
+                    AndroidUtilities.runOnUIThread(onVideoStartRecord);
+                }
+            } catch (Exception e) {
+                recorder.release();
+                recorder = null;
+                FileLog.e(e);
+            }
+        });
+    }
+
+    @Override
+    public void onInfo(MediaRecorder mediaRecorder, int what, int extra) {
+        if (what == MediaRecorder.MEDIA_RECORDER_INFO_MAX_DURATION_REACHED || what == MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED || what == MediaRecorder.MEDIA_RECORDER_INFO_UNKNOWN) {
+            MediaRecorder tempRecorder = recorder;
+            recorder = null;
+            if (tempRecorder != null) {
+                tempRecorder.stop();
+                tempRecorder.release();
+            }
+            if (onVideoTakeCallback != null) {
+                finishRecordingVideo();
+            }
+        }
+    }
+
+    private void finishRecordingVideo() {
+        MediaMetadataRetriever mediaMetadataRetriever = null;
+        long duration = 0;
+        try {
+            mediaMetadataRetriever = new MediaMetadataRetriever();
+            mediaMetadataRetriever.setDataSource(recordedFile);
+            String d = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
+            if (d != null) {
+                duration = (int) Math.ceil(Long.parseLong(d) / 1000.0f);
+            }
+        } catch (Exception e) {
+            FileLog.e(e);
+        } finally {
+            try {
+                if (mediaMetadataRetriever != null) {
+                    mediaMetadataRetriever.release();
+                }
+            } catch (Exception e) {
+                FileLog.e(e);
+            }
+        }
+        Bitmap bitmap = SendMessagesHelper.createVideoThumbnail(recordedFile, MediaStore.Video.Thumbnails.MINI_KIND);
+        if (mirrorRecorderVideo) {
+            Bitmap b = Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(b);
+            canvas.scale(-1, 1, b.getWidth() / 2, b.getHeight() / 2);
+            canvas.drawBitmap(bitmap, 0, 0, null);
+            bitmap.recycle();
+            bitmap = b;
+        }
+        String fileName = Integer.MIN_VALUE + "_" + SharedConfig.getLastLocalId() + ".jpg";
+        final File cacheFile = new File(FileLoader.getDirectory(FileLoader.MEDIA_DIR_CACHE), fileName);
+        try {
+            FileOutputStream stream = new FileOutputStream(cacheFile);
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 87, stream);
+        } catch (Throwable e) {
+            FileLog.e(e);
+        }
+        SharedConfig.saveConfig();
+        final long durationFinal = duration;
+        final Bitmap bitmapFinal = bitmap;
+        AndroidUtilities.runOnUIThread(() -> {
+            if (onVideoTakeCallback != null) {
+                String path = cacheFile.getAbsolutePath();
+                if (bitmapFinal != null) {
+                    ImageLoader.getInstance().putImageToCache(new BitmapDrawable(bitmapFinal), Utilities.MD5(path));
+                }
+                onVideoTakeCallback.onFinishVideoRecording(path, durationFinal);
+                onVideoTakeCallback = null;
+            }
+        });
+    }
+
+    @Override
+    public void stopVideoRecording(CameraSession session, boolean abandon) {
+        threadPool.execute(() -> {
+            if (recorder != null) {
+                MediaRecorder tempRecorder = recorder;
+                recorder = null;
+                try {
+                    tempRecorder.stop();
+                } catch (Exception e) {
+                    FileLog.e(e);
+                }
+                try {
+                    tempRecorder.release();
+                } catch (Exception e) {
+                    FileLog.e(e);
+                }
+                availableCameras[session.cameraInfo.cameraId].stopVideo();
+                try {
+                    session.stopVideoRecording();
+                } catch (Exception e) {
+                    FileLog.e(e);
+                }
+            }
+
+            if (!abandon && onVideoTakeCallback != null) {
+                finishRecordingVideo();
+            } else {
+                onVideoTakeCallback = null;
+            }
+        });
+    }
+
+    @Override
+    public void cancelOnInitRunnable(Runnable onInitRunnable) {
+        onFinishCameraInitRunnables.remove(onInitRunnable);
+    }
+
+    @Override
+    public ArrayList<CameraInfo> getCameras() {
+        return cameraInfos;
+    }
+
+    interface PhotoTakeCallback {
+        void onPhotoTaken(byte[] photoBytes);
+    }
+
+    public static class CameraService {
+
+        final private String cameraId;
+        final private CameraManager cameraManager;
+        final private int rotationCompensation;
+
+        private CameraDevice cameraDevice = null;
+        private CameraCaptureSession captureSession;
+        private ImageReader imageReader;
+        private MediaRecorder mediaRecorder;
+        private PhotoTakeCallback callback;private Surface surface;
+        private Handler backgroundHandler;
+
+        private final ImageReader.OnImageAvailableListener onImageAvailableListener = new ImageReader.OnImageAvailableListener() {
+
+            @Override
+            public void onImageAvailable(ImageReader reader) {
+                Image image = reader.acquireNextImage();
+                ByteBuffer buffer = image.getPlanes()[0].getBuffer();
+                byte[] bytes = new byte[buffer.remaining()];
+                buffer.get(bytes);
+                if (callback != null) {
+                    callback.onPhotoTaken(bytes);
+                }
+            }
+
+        };
+
+        private final CameraDevice.StateCallback cameraCallback = new CameraDevice.StateCallback() {
+
+            @Override
+            public void onOpened(CameraDevice camera) {
+                cameraDevice = camera;
+                createCameraPreviewSession();
+            }
+
+            @Override
+            public void onDisconnected(CameraDevice camera) {
+                cameraDevice.close();
+                cameraDevice = null;
+            }
+
+            @Override
+            public void onError(CameraDevice camera, int error) {
+                FileLog.d("camera2 open error = " + error);
+            }
+        };
+
+        public CameraService(CameraManager cameraManager, String cameraID, Handler backgroundHandler, int rotationCompensation) {
+            this.cameraManager = cameraManager;
+            this.cameraId = cameraID;
+            this.backgroundHandler = backgroundHandler;
+            this.rotationCompensation = rotationCompensation;
+        }
+
+        public void relaunchPreview() {
+            try {
+                final CaptureRequest.Builder builder = cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW);
+
+                builder.addTarget(surface);
+
+                if (mediaRecorder != null) {
+                    Surface recorderSurface = mediaRecorder.getSurface();
+                    builder.addTarget(recorderSurface);
+                }
+
+                List<Surface> sessionSurfaces = mediaRecorder == null ? Arrays.asList(surface, imageReader.getSurface()) : Arrays.asList(surface, imageReader.getSurface(), mediaRecorder.getSurface());
+
+                cameraDevice.createCaptureSession(sessionSurfaces,
+                    new CameraCaptureSession.StateCallback() {
+
+                        @Override
+                        public void onConfigured(CameraCaptureSession session) {
+                            captureSession = session;
+                            try {
+                                captureSession.setRepeatingRequest(builder.build(), null, backgroundHandler);
+                            } catch (CameraAccessException e) {
+                                e.printStackTrace();
+                            }
+                        }
+
+                        @Override
+                        public void onConfigureFailed(CameraCaptureSession session) {
+                        }
+                    }, backgroundHandler);
+            } catch (CameraAccessException e) {
+                e.printStackTrace();
+            }
+        }
+
+        private void createCameraPreviewSession() { // width and height could be taken from camera params
+            imageReader = ImageReader.newInstance(1920, 1080, ImageFormat.JPEG, 1);
+            imageReader.setOnImageAvailableListener(onImageAvailableListener, null);
+            relaunchPreview();
+        }
+
+        public void stopPreview() {
+            try {
+                captureSession.stopRepeating();
+                captureSession.abortCaptures();
+                captureSession.close();
+            } catch (CameraAccessException e) {
+                e.printStackTrace();
+            }
+        }
+
+        public void makePhoto(PhotoTakeCallback photoTakeCallback) {
+            try {
+                final CaptureRequest.Builder captureBuilder = cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_STILL_CAPTURE);
+                captureBuilder.addTarget(imageReader.getSurface());
+                CameraCaptureSession.CaptureCallback CaptureCallback = new CameraCaptureSession.CaptureCallback() {
+
+                    @Override
+                    public void onCaptureCompleted(@NonNull CameraCaptureSession session,
+                                                   @NonNull CaptureRequest request,
+                                                   @NonNull TotalCaptureResult result) {
+                    }
+                };
+
+                captureSession.stopRepeating();
+                captureSession.abortCaptures();
+                captureSession.capture(captureBuilder.build(), CaptureCallback, backgroundHandler);
+                callback = photoTakeCallback;
+            } catch (CameraAccessException e) {
+                e.printStackTrace();
+            }
+        }
+
+        public void stopVideo() {
+            try {
+                captureSession.stopRepeating();
+                captureSession.abortCaptures();
+                captureSession.close();
+            } catch (CameraAccessException e) {
+                e.printStackTrace();
+            }
+            this.mediaRecorder = null;
+        }
+
+        public void recordVideo(MediaRecorder mediaRecorder) {
+            this.mediaRecorder = mediaRecorder;
+            relaunchPreview();
+        }
+
+        public void clearCallback() {
+            callback = null;
+        }
+
+        public void setBackgroundHandler(Handler backgroundHandler) {
+            this.backgroundHandler = backgroundHandler;
+        }
+
+        public boolean isOpen() {
+            return cameraDevice != null;
+        }
+
+        @SuppressLint("MissingPermission")
+        public void openCamera(SurfaceTexture texture) {
+            surface = new Surface(texture);
+            try {
+                cameraManager.openCamera(cameraId, cameraCallback, backgroundHandler);
+            } catch (CameraAccessException e) {
+                FileLog.d("openCamera error = " + e.getMessage());
+            }
+        }
+
+
+        public void closeCamera() {
+            if (cameraDevice != null) {
+                cameraDevice.close();
+                cameraDevice = null;
+            }
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/org/telegram/messenger/camera/CameraController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/camera/CameraController.java
@@ -8,65 +8,34 @@
 
 package org.telegram.messenger.camera;
 
-import android.content.SharedPreferences;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.graphics.Canvas;
-import android.graphics.Matrix;
+import android.annotation.SuppressLint;
+import android.content.Context;
 import android.graphics.SurfaceTexture;
-import android.graphics.drawable.BitmapDrawable;
-import android.hardware.Camera;
-import android.media.MediaMetadataRetriever;
-import android.media.MediaRecorder;
+import android.hardware.camera2.CameraAccessException;
+import android.hardware.camera2.CameraCharacteristics;
+import android.hardware.camera2.CameraManager;
+import android.hardware.camera2.CameraMetadata;
 import android.os.Build;
-import android.provider.MediaStore;
-import android.util.Base64;
-
-import org.telegram.messenger.AndroidUtilities;
 import org.telegram.messenger.ApplicationLoader;
-import org.telegram.messenger.Bitmaps;
-import org.telegram.messenger.BuildVars;
-import org.telegram.messenger.FileLoader;
-import org.telegram.messenger.FileLog;
-import org.telegram.messenger.ImageLoader;
-import org.telegram.messenger.MessagesController;
-import org.telegram.messenger.NotificationCenter;
-import org.telegram.messenger.SendMessagesHelper;
-import org.telegram.messenger.SharedConfig;
-import org.telegram.messenger.Utilities;
-import org.telegram.tgnet.SerializedData;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
-public class CameraController implements MediaRecorder.OnInfoListener {
 
-    private static final int CORE_POOL_SIZE = 1;
-    private static final int MAX_POOL_SIZE = 1;
-    private static final int KEEP_ALIVE_SECONDS = 60;
+public class CameraController {
 
-    private ThreadPoolExecutor threadPool;
-    protected ArrayList<String> availableFlashModes = new ArrayList<>();
-    private MediaRecorder recorder;
-    private String recordedFile;
-    private boolean mirrorRecorderVideo;
-    protected volatile ArrayList<CameraInfo> cameraInfos;
-    private VideoTakeCallback onVideoTakeCallback;
-    private boolean cameraInitied;
-    private boolean loadingCameras;
-
-    private ArrayList<Runnable> onFinishCameraInitRunnables = new ArrayList<>();
+    private static final int FACING_BACK = 0;
+    private static final int FACING_FRONT = 1;
+    private static final String FACING_BACK_STR = String.valueOf(FACING_BACK);
+    private static final String FACING_FRONT_STR = String.valueOf(FACING_FRONT);
 
     private static volatile CameraController Instance = null;
+    private final ICameraController cameraControllerImp;
+    public final boolean isCamera2Used;
 
     public interface VideoTakeCallback {
         void onFinishVideoRecording(String thumbPath, long duration);
@@ -85,696 +54,98 @@ public class CameraController implements MediaRecorder.OnInfoListener {
         return localInstance;
     }
 
+
+    @SuppressLint("NewApi")
     public CameraController() {
-        threadPool = new ThreadPoolExecutor(CORE_POOL_SIZE, MAX_POOL_SIZE, KEEP_ALIVE_SECONDS, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+        isCamera2Used = haveAppropriateCamera2Support();
+        cameraControllerImp = isCamera2Used ? new Camera2Controller() : new Camera1Controller();
     }
 
-    public void cancelOnInitRunnable(final Runnable onInitRunnable) {
-        onFinishCameraInitRunnables.remove(onInitRunnable);
+    public ArrayList<String> getAvailableFlashModes() {
+        return cameraControllerImp.availableFlashModes;
     }
 
-    public void initCamera(final Runnable onInitRunnable) {
-        initCamera(onInitRunnable, false);
-    }
-
-    private void initCamera(final Runnable onInitRunnable, boolean withDelay) {
-        if (cameraInitied) {
-            return;
-        }
-        if (onInitRunnable != null && !onFinishCameraInitRunnables.contains(onInitRunnable)) {
-            onFinishCameraInitRunnables.add(onInitRunnable);
-        }
-        if (loadingCameras || cameraInitied) {
-            return;
-        }
-        loadingCameras = true;
-        threadPool.execute(() -> {
+    private boolean haveAppropriateCamera2Support() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            CameraManager cameraManager = (CameraManager) ApplicationLoader.applicationContext.getSystemService(Context.CAMERA_SERVICE);
             try {
-                if (cameraInfos == null) {
-                    SharedPreferences preferences = MessagesController.getGlobalMainSettings();
-                    String cache = preferences.getString("cameraCache", null);
-                    Comparator<Size> comparator = (o1, o2) -> {
-                        if (o1.mWidth < o2.mWidth) {
-                            return 1;
-                        } else if (o1.mWidth > o2.mWidth) {
-                            return -1;
-                        } else {
-                            if (o1.mHeight < o2.mHeight) {
-                                return 1;
-                            } else if (o1.mHeight > o2.mHeight) {
-                                return -1;
-                            }
-                            return 0;
-                        }
-                    };
-                    ArrayList<CameraInfo> result = new ArrayList<>();
-                    if (cache != null) {
-                        SerializedData serializedData = new SerializedData(Base64.decode(cache, Base64.DEFAULT));
-                        int count = serializedData.readInt32(false);
-                        for (int a = 0; a < count; a++) {
-                            CameraInfo cameraInfo = new CameraInfo(serializedData.readInt32(false), serializedData.readInt32(false));
-                            int pCount = serializedData.readInt32(false);
-                            for (int b = 0; b < pCount; b++) {
-                                cameraInfo.previewSizes.add(new Size(serializedData.readInt32(false), serializedData.readInt32(false)));
-                            }
-                            pCount = serializedData.readInt32(false);
-                            for (int b = 0; b < pCount; b++) {
-                                cameraInfo.pictureSizes.add(new Size(serializedData.readInt32(false), serializedData.readInt32(false)));
-                            }
-                            result.add(cameraInfo);
-
-                            Collections.sort(cameraInfo.previewSizes, comparator);
-                            Collections.sort(cameraInfo.pictureSizes, comparator);
-                        }
-                        serializedData.cleanup();
-                    } else {
-                        int count = Camera.getNumberOfCameras();
-                        Camera.CameraInfo info = new Camera.CameraInfo();
-
-                        int bufferSize = 4;
-                        for (int cameraId = 0; cameraId < count; cameraId++) {
-                            Camera.getCameraInfo(cameraId, info);
-                            CameraInfo cameraInfo = new CameraInfo(cameraId, info.facing);
-
-                            if (ApplicationLoader.mainInterfacePaused && ApplicationLoader.externalInterfacePaused) {
-                                throw new RuntimeException("APP_PAUSED");
-                            }
-                            Camera camera = Camera.open(cameraInfo.getCameraId());
-                            Camera.Parameters params = camera.getParameters();
-
-                            List<Camera.Size> list = params.getSupportedPreviewSizes();
-                            for (int a = 0; a < list.size(); a++) {
-                                Camera.Size size = list.get(a);
-                                if (size.width == 1280 && size.height != 720) {
-                                    continue;
-                                }
-                                if (size.height < 2160 && size.width < 2160) {
-                                    cameraInfo.previewSizes.add(new Size(size.width, size.height));
-                                    if (BuildVars.LOGS_ENABLED) {
-                                        FileLog.d("preview size = " + size.width + " " + size.height);
-                                    }
-                                }
-                            }
-
-                            list = params.getSupportedPictureSizes();
-                            for (int a = 0; a < list.size(); a++) {
-                                Camera.Size size = list.get(a);
-                                if (size.width == 1280 && size.height != 720) {
-                                    continue;
-                                }
-                                if (!"samsung".equals(Build.MANUFACTURER) || !"jflteuc".equals(Build.PRODUCT) || size.width < 2048) {
-                                    cameraInfo.pictureSizes.add(new Size(size.width, size.height));
-                                    if (BuildVars.LOGS_ENABLED) {
-                                        FileLog.d("picture size = " + size.width + " " + size.height);
-                                    }
-                                }
-                            }
-
-                            camera.release();
-                            result.add(cameraInfo);
-
-                            Collections.sort(cameraInfo.previewSizes, comparator);
-                            Collections.sort(cameraInfo.pictureSizes, comparator);
-
-                            bufferSize += 4 + 4 + 8 * (cameraInfo.previewSizes.size() + cameraInfo.pictureSizes.size());
-                        }
-
-                        SerializedData serializedData = new SerializedData(bufferSize);
-                        serializedData.writeInt32(result.size());
-                        for (int a = 0; a < count; a++) {
-                            CameraInfo cameraInfo = result.get(a);
-                            serializedData.writeInt32(cameraInfo.cameraId);
-                            serializedData.writeInt32(cameraInfo.frontCamera);
-
-                            int pCount = cameraInfo.previewSizes.size();
-                            serializedData.writeInt32(pCount);
-                            for (int b = 0; b < pCount; b++) {
-                                Size size = cameraInfo.previewSizes.get(b);
-                                serializedData.writeInt32(size.mWidth);
-                                serializedData.writeInt32(size.mHeight);
-                            }
-                            pCount = cameraInfo.pictureSizes.size();
-                            serializedData.writeInt32(pCount);
-                            for (int b = 0; b < pCount; b++) {
-                                Size size = cameraInfo.pictureSizes.get(b);
-                                serializedData.writeInt32(size.mWidth);
-                                serializedData.writeInt32(size.mHeight);
-                            }
-                        }
-                        preferences.edit().putString("cameraCache", Base64.encodeToString(serializedData.toByteArray(), Base64.DEFAULT)).commit();
-                        serializedData.cleanup();
-                    }
-                    cameraInfos = result;
+                boolean backSupport = false;
+                boolean frontSupport = false;
+                CameraCharacteristics characteristics = cameraManager.getCameraCharacteristics(FACING_BACK_STR);
+                // check that both cameras mostly have camera2 support
+                if (characteristics != null) {
+                    int mainSupportData = characteristics.get(CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL);
+                    backSupport = mainSupportData == CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_FULL ||
+                        mainSupportData == CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_LIMITED ||
+                        mainSupportData == CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_3;
                 }
-                AndroidUtilities.runOnUIThread(() -> {
-                    loadingCameras = false;
-                    cameraInitied = true;
-                    if (!onFinishCameraInitRunnables.isEmpty()) {
-                        for (int a = 0; a < onFinishCameraInitRunnables.size(); a++) {
-                            onFinishCameraInitRunnables.get(a).run();
-                        }
-                        onFinishCameraInitRunnables.clear();
-                    }
-                    NotificationCenter.getGlobalInstance().postNotificationName(NotificationCenter.cameraInitied);
-                });
-            } catch (Exception e) {
-                AndroidUtilities.runOnUIThread(() -> {
-                    onFinishCameraInitRunnables.clear();
-                    loadingCameras = false;
-                    cameraInitied = false;
-                    if (!withDelay && "APP_PAUSED".equals(e.getMessage())) {
-                        AndroidUtilities.runOnUIThread(() -> initCamera(onInitRunnable, true), 1000);
-                    }
-                });
 
-            }
-        });
-    }
-
-    public boolean isCameraInitied() {
-        return cameraInitied && cameraInfos != null && !cameraInfos.isEmpty();
-    }
-
-    public void runOnThreadPool(Runnable runnable) {
-        threadPool.execute(runnable);
-    }
-
-    public void close(final CameraSession session, final CountDownLatch countDownLatch, final Runnable beforeDestroyRunnable) {
-        session.destroy();
-        threadPool.execute(() -> {
-            if (beforeDestroyRunnable != null) {
-                beforeDestroyRunnable.run();
-            }
-            if (session.cameraInfo.camera != null) {
-                try {
-                    session.cameraInfo.camera.stopPreview();
-                    session.cameraInfo.camera.setPreviewCallbackWithBuffer(null);
-                } catch (Exception e) {
-                    FileLog.e(e);
+                characteristics = cameraManager.getCameraCharacteristics(FACING_FRONT_STR);
+                if (characteristics != null) {
+                    int mainSupportData = characteristics.get(CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL);
+                    frontSupport = mainSupportData == CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_FULL ||
+                        mainSupportData == CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_LIMITED ||
+                        mainSupportData == CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_3;
                 }
-                try {
-                    session.cameraInfo.camera.release();
-                } catch (Exception e) {
-                    FileLog.e(e);
-                }
-                session.cameraInfo.camera = null;
+                return backSupport && frontSupport;
+            } catch (@SuppressLint("NewApi") CameraAccessException cameraAccessException) {
+                cameraAccessException.printStackTrace();
             }
-            if (countDownLatch != null) {
-                countDownLatch.countDown();
-            }
-        });
-        if (countDownLatch != null) {
-            try {
-                countDownLatch.await();
-            } catch (Exception e) {
-                FileLog.e(e);
-            }
-        }
-    }
-
-    public ArrayList<CameraInfo> getCameras() {
-        return cameraInfos;
-    }
-
-    private static int getOrientation(byte[] jpeg) {
-        if (jpeg == null) {
-            return 0;
-        }
-
-        int offset = 0;
-        int length = 0;
-
-        while (offset + 3 < jpeg.length && (jpeg[offset++] & 0xFF) == 0xFF) {
-            int marker = jpeg[offset] & 0xFF;
-
-            if (marker == 0xFF) {
-                continue;
-            }
-            offset++;
-
-            if (marker == 0xD8 || marker == 0x01) {
-                continue;
-            }
-            if (marker == 0xD9 || marker == 0xDA) {
-                break;
-            }
-
-            length = pack(jpeg, offset, 2, false);
-            if (length < 2 || offset + length > jpeg.length) {
-                return 0;
-            }
-
-            // Break if the marker is EXIF in APP1.
-            if (marker == 0xE1 && length >= 8 &&
-                    pack(jpeg, offset + 2, 4, false) == 0x45786966 &&
-                    pack(jpeg, offset + 6, 2, false) == 0) {
-                offset += 8;
-                length -= 8;
-                break;
-            }
-
-            offset += length;
-            length = 0;
-        }
-
-        if (length > 8) {
-            int tag = pack(jpeg, offset, 4, false);
-            if (tag != 0x49492A00 && tag != 0x4D4D002A) {
-                return 0;
-            }
-            boolean littleEndian = (tag == 0x49492A00);
-
-            int count = pack(jpeg, offset + 4, 4, littleEndian) + 2;
-            if (count < 10 || count > length) {
-                return 0;
-            }
-            offset += count;
-            length -= count;
-
-            count = pack(jpeg, offset - 2, 2, littleEndian);
-            while (count-- > 0 && length >= 12) {
-                tag = pack(jpeg, offset, 2, littleEndian);
-                if (tag == 0x0112) {
-                    int orientation = pack(jpeg, offset + 8, 2, littleEndian);
-                    switch (orientation) {
-                        case 1:
-                            return 0;
-                        case 3:
-                            return 180;
-                        case 6:
-                            return 90;
-                        case 8:
-                            return 270;
-                    }
-                    return 0;
-                }
-                offset += 12;
-                length -= 12;
-            }
-        }
-        return 0;
-    }
-
-    private static int pack(byte[] bytes, int offset, int length, boolean littleEndian) {
-        int step = 1;
-        if (littleEndian) {
-            offset += length - 1;
-            step = -1;
-        }
-
-        int value = 0;
-        while (length-- > 0) {
-            value = (value << 8) | (bytes[offset] & 0xFF);
-            offset += step;
-        }
-        return value;
-    }
-
-    public boolean takePicture(final File path, final CameraSession session, final Runnable callback) {
-        if (session == null) {
-            return false;
-        }
-        final CameraInfo info = session.cameraInfo;
-        final boolean flipFront = session.isFlipFront();
-        Camera camera = info.camera;
-        try {
-            camera.takePicture(null, null, (data, camera1) -> {
-                Bitmap bitmap = null;
-                int size = (int) (AndroidUtilities.getPhotoSize() / AndroidUtilities.density);
-                String key = String.format(Locale.US, "%s@%d_%d", Utilities.MD5(path.getAbsolutePath()), size, size);
-                try {
-                    BitmapFactory.Options options = new BitmapFactory.Options();
-                    options.inJustDecodeBounds = true;
-                    BitmapFactory.decodeByteArray(data, 0, data.length, options);
-                    float scaleFactor = Math.max((float) options.outWidth / AndroidUtilities.getPhotoSize(), (float) options.outHeight / AndroidUtilities.getPhotoSize());
-                    if (scaleFactor < 1) {
-                        scaleFactor = 1;
-                    }
-                    options.inJustDecodeBounds = false;
-                    options.inSampleSize = (int) scaleFactor;
-                    options.inPurgeable = true;
-                    bitmap = BitmapFactory.decodeByteArray(data, 0, data.length, options);
-                } catch (Throwable e) {
-                    FileLog.e(e);
-                }
-                try {
-                    if (info.frontCamera != 0 && flipFront) {
-                        try {
-                            Matrix matrix = new Matrix();
-                            matrix.setRotate(getOrientation(data));
-                            matrix.postScale(-1, 1);
-                            Bitmap scaled = Bitmaps.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
-                            if (scaled != bitmap) {
-                                bitmap.recycle();
-                            }
-                            FileOutputStream outputStream = new FileOutputStream(path);
-                            scaled.compress(Bitmap.CompressFormat.JPEG, 80, outputStream);
-                            outputStream.flush();
-                            outputStream.getFD().sync();
-                            outputStream.close();
-                            if (scaled != null) {
-                                ImageLoader.getInstance().putImageToCache(new BitmapDrawable(scaled), key);
-                            }
-                            if (callback != null) {
-                                callback.run();
-                            }
-                            return;
-                        } catch (Throwable e) {
-                            FileLog.e(e);
-                        }
-                    }
-                    FileOutputStream outputStream = new FileOutputStream(path);
-                    outputStream.write(data);
-                    outputStream.flush();
-                    outputStream.getFD().sync();
-                    outputStream.close();
-                    if (bitmap != null) {
-                        ImageLoader.getInstance().putImageToCache(new BitmapDrawable(bitmap), key);
-                    }
-                } catch (Exception e) {
-                    FileLog.e(e);
-                }
-                if (callback != null) {
-                    callback.run();
-                }
-            });
-            return true;
-        } catch (Exception e) {
-            FileLog.e(e);
         }
         return false;
     }
 
+    public void cancelOnInitRunnable(final Runnable onInitRunnable) {
+        cameraControllerImp.cancelOnInitRunnable(onInitRunnable);
+    }
+
+    public void initCamera(final Runnable onInitRunnable) {
+        cameraControllerImp.initCamera(onInitRunnable);
+    }
+
+    public boolean isCameraInitied() {
+        return cameraControllerImp.isCameraInitied();
+    }
+
+    public void close(final CameraSession session, final CountDownLatch countDownLatch, final Runnable beforeDestroyRunnable) {
+        cameraControllerImp.close(session, countDownLatch, beforeDestroyRunnable);
+    }
+
+    public ArrayList<CameraInfo> getCameras() {
+        return cameraControllerImp.getCameras();
+    }
+
+    public boolean takePicture(final File path, final CameraSession session, final Runnable callback) {
+        return cameraControllerImp.takePicture(path, session, callback);
+    }
+
     public void startPreview(final CameraSession session) {
-        if (session == null) {
-            return;
-        }
-        threadPool.execute(() -> {
-            Camera camera = session.cameraInfo.camera;
-            try {
-                if (camera == null) {
-                    camera = session.cameraInfo.camera = Camera.open(session.cameraInfo.cameraId);
-                }
-                camera.startPreview();
-            } catch (Exception e) {
-                session.cameraInfo.camera = null;
-                if (camera != null) {
-                    camera.release();
-                }
-                FileLog.e(e);
-            }
-        });
+        cameraControllerImp.startPreview(session);
     }
 
     public void stopPreview(final CameraSession session) {
-        if (session == null) {
-            return;
-        }
-        threadPool.execute(() -> {
-            Camera camera = session.cameraInfo.camera;
-            try {
-                if (camera == null) {
-                    camera = session.cameraInfo.camera = Camera.open(session.cameraInfo.cameraId);
-                }
-                camera.stopPreview();
-            } catch (Exception e) {
-                session.cameraInfo.camera = null;
-                if (camera != null) {
-                    camera.release();
-                }
-                FileLog.e(e);
-            }
-        });
+        cameraControllerImp.stopPreview(session);
     }
 
     public void openRound(final CameraSession session, final SurfaceTexture texture, final Runnable callback, final Runnable configureCallback) {
-        if (session == null || texture == null) {
-            if (BuildVars.LOGS_ENABLED) {
-                FileLog.d("failed to open round " + session + " tex = " + texture);
-            }
-            return;
-        }
-        threadPool.execute(() -> {
-            Camera camera = session.cameraInfo.camera;
-            try {
-                if (BuildVars.LOGS_ENABLED) {
-                    FileLog.d("start creating round camera session");
-                }
-                if (camera == null) {
-                    camera = session.cameraInfo.camera = Camera.open(session.cameraInfo.cameraId);
-                }
-                Camera.Parameters params = camera.getParameters();
-
-                session.configureRoundCamera();
-                if (configureCallback != null) {
-                    configureCallback.run();
-                }
-                camera.setPreviewTexture(texture);
-                camera.startPreview();
-                if (callback != null) {
-                    AndroidUtilities.runOnUIThread(callback);
-                }
-                if (BuildVars.LOGS_ENABLED) {
-                    FileLog.d("round camera session created");
-                }
-            } catch (Exception e) {
-                session.cameraInfo.camera = null;
-                if (camera != null) {
-                    camera.release();
-                }
-                FileLog.e(e);
-            }
-        });
+        cameraControllerImp.openRound(session, texture, callback, configureCallback);
     }
 
     public void open(final CameraSession session, final SurfaceTexture texture, final Runnable callback, final Runnable prestartCallback) {
-        if (session == null || texture == null) {
-            return;
-        }
-        threadPool.execute(() -> {
-            Camera camera = session.cameraInfo.camera;
-            try {
-                if (camera == null) {
-                    camera = session.cameraInfo.camera = Camera.open(session.cameraInfo.cameraId);
-                }
-                Camera.Parameters params = camera.getParameters();
-                List<String> rawFlashModes = params.getSupportedFlashModes();
-
-                availableFlashModes.clear();
-                if (rawFlashModes != null) {
-                    for (int a = 0; a < rawFlashModes.size(); a++) {
-                        String rawFlashMode = rawFlashModes.get(a);
-                        if (rawFlashMode.equals(Camera.Parameters.FLASH_MODE_OFF) || rawFlashMode.equals(Camera.Parameters.FLASH_MODE_ON) || rawFlashMode.equals(Camera.Parameters.FLASH_MODE_AUTO)) {
-                            availableFlashModes.add(rawFlashMode);
-                        }
-                    }
-                    session.checkFlashMode(availableFlashModes.get(0));
-                }
-
-                if (prestartCallback != null) {
-                    prestartCallback.run();
-                }
-
-                session.configurePhotoCamera();
-                camera.setPreviewTexture(texture);
-                camera.startPreview();
-                if (callback != null) {
-                    AndroidUtilities.runOnUIThread(callback);
-                }
-            } catch (Exception e) {
-                session.cameraInfo.camera = null;
-                if (camera != null) {
-                    camera.release();
-                }
-                FileLog.e(e);
-            }
-        });
+        cameraControllerImp.open(session, texture, callback, prestartCallback);
     }
 
     public void recordVideo(final CameraSession session, final File path, boolean mirror, final VideoTakeCallback callback, final Runnable onVideoStartRecord) {
-        if (session == null) {
-            return;
-        }
-
-        final CameraInfo info = session.cameraInfo;
-        final Camera camera = info.camera;
-        threadPool.execute(() -> {
-            try {
-                if (camera != null) {
-                    try {
-                        Camera.Parameters params = camera.getParameters();
-                        params.setFlashMode(session.getCurrentFlashMode().equals(Camera.Parameters.FLASH_MODE_ON) ? Camera.Parameters.FLASH_MODE_TORCH : Camera.Parameters.FLASH_MODE_OFF);
-                        camera.setParameters(params);
-                    } catch (Exception e) {
-                        FileLog.e(e);
-                    }
-                    camera.unlock();
-                    //camera.stopPreview();
-                    try {
-                        mirrorRecorderVideo = mirror;
-                        recorder = new MediaRecorder();
-                        recorder.setCamera(camera);
-                        recorder.setVideoSource(MediaRecorder.VideoSource.CAMERA);
-                        recorder.setAudioSource(MediaRecorder.AudioSource.CAMCORDER);
-                        session.configureRecorder(1, recorder);
-                        recorder.setOutputFile(path.getAbsolutePath());
-                        recorder.setMaxFileSize(1024 * 1024 * 1024);
-                        recorder.setVideoFrameRate(30);
-                        recorder.setMaxDuration(0);
-                        Size pictureSize;
-                        pictureSize = new Size(16, 9);
-                        pictureSize = CameraController.chooseOptimalSize(info.getPictureSizes(), 720, 480, pictureSize);
-                        int bitrate;
-                        if (Math.min(pictureSize.mHeight,pictureSize.mWidth) >= 720) {
-                            bitrate = 3500000;
-                        } else {
-                            bitrate = 1800000;
-                        }
-                        recorder.setVideoEncodingBitRate(bitrate);
-                        recorder.setVideoSize(pictureSize.getWidth(), pictureSize.getHeight());
-                        recorder.setOnInfoListener(CameraController.this);
-                        recorder.prepare();
-                        recorder.start();
-
-                        onVideoTakeCallback = callback;
-                        recordedFile = path.getAbsolutePath();
-                        if (onVideoStartRecord != null) {
-                            AndroidUtilities.runOnUIThread(onVideoStartRecord);
-                        }
-                    } catch (Exception e) {
-                        recorder.release();
-                        recorder = null;
-                        FileLog.e(e);
-                    }
-                }
-            } catch (Exception e) {
-                FileLog.e(e);
-            }
-        });
-    }
-
-    private void finishRecordingVideo() {
-        MediaMetadataRetriever mediaMetadataRetriever = null;
-        long duration = 0;
-        try {
-            mediaMetadataRetriever = new MediaMetadataRetriever();
-            mediaMetadataRetriever.setDataSource(recordedFile);
-            String d = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
-            if (d != null) {
-                duration = (int) Math.ceil(Long.parseLong(d) / 1000.0f);
-            }
-        } catch (Exception e) {
-            FileLog.e(e);
-        } finally {
-            try {
-                if (mediaMetadataRetriever != null) {
-                    mediaMetadataRetriever.release();
-                }
-            } catch (Exception e) {
-                FileLog.e(e);
-            }
-        }
-        Bitmap bitmap = SendMessagesHelper.createVideoThumbnail(recordedFile, MediaStore.Video.Thumbnails.MINI_KIND);
-        if (mirrorRecorderVideo) {
-            Bitmap b = Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), Bitmap.Config.ARGB_8888);
-            Canvas canvas = new Canvas(b);
-            canvas.scale(-1, 1, b.getWidth() / 2, b.getHeight() / 2);
-            canvas.drawBitmap(bitmap, 0, 0, null);
-            bitmap.recycle();
-            bitmap = b;
-        }
-        String fileName = Integer.MIN_VALUE + "_" + SharedConfig.getLastLocalId() + ".jpg";
-        final File cacheFile = new File(FileLoader.getDirectory(FileLoader.MEDIA_DIR_CACHE), fileName);
-        try {
-            FileOutputStream stream = new FileOutputStream(cacheFile);
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 87, stream);
-        } catch (Throwable e) {
-            FileLog.e(e);
-        }
-        SharedConfig.saveConfig();
-        final long durationFinal = duration;
-        final Bitmap bitmapFinal = bitmap;
-        AndroidUtilities.runOnUIThread(() -> {
-            if (onVideoTakeCallback != null) {
-                String path = cacheFile.getAbsolutePath();
-                if (bitmapFinal != null) {
-                    ImageLoader.getInstance().putImageToCache(new BitmapDrawable(bitmapFinal), Utilities.MD5(path));
-                }
-                onVideoTakeCallback.onFinishVideoRecording(path, durationFinal);
-                onVideoTakeCallback = null;
-            }
-        });
-    }
-
-    @Override
-    public void onInfo(MediaRecorder mediaRecorder, int what, int extra) {
-        if (what == MediaRecorder.MEDIA_RECORDER_INFO_MAX_DURATION_REACHED || what == MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED || what == MediaRecorder.MEDIA_RECORDER_INFO_UNKNOWN) {
-            MediaRecorder tempRecorder = recorder;
-            recorder = null;
-            if (tempRecorder != null) {
-                tempRecorder.stop();
-                tempRecorder.release();
-            }
-            if (onVideoTakeCallback != null) {
-                finishRecordingVideo();
-            }
-        }
+        cameraControllerImp.recordVideo(session, path, mirror, callback, onVideoStartRecord);
     }
 
     public void stopVideoRecording(final CameraSession session, final boolean abandon) {
-        threadPool.execute(() -> {
-            try {
-                CameraInfo info = session.cameraInfo;
-                final Camera camera = info.camera;
-                if (camera != null && recorder != null) {
-                    MediaRecorder tempRecorder = recorder;
-                    recorder = null;
-                    try {
-                        tempRecorder.stop();
-                    } catch (Exception e) {
-                        FileLog.e(e);
-                    }
-                    try {
-                        tempRecorder.release();
-                    } catch (Exception e) {
-                        FileLog.e(e);
-                    }
-                    try {
-                        camera.reconnect();
-                        camera.startPreview();
-                    } catch (Exception e) {
-                        FileLog.e(e);
-                    }
-                    try {
-                        session.stopVideoRecording();
-                    } catch (Exception e) {
-                        FileLog.e(e);
-                    }
-                }
-                try {
-                    Camera.Parameters params = camera.getParameters();
-                    params.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
-                    camera.setParameters(params);
-                } catch (Exception e) {
-                    FileLog.e(e);
-                }
-                threadPool.execute(() -> {
-                    try {
-                        Camera.Parameters params = camera.getParameters();
-                        params.setFlashMode(session.getCurrentFlashMode());
-                        camera.setParameters(params);
-                    } catch (Exception e) {
-                        FileLog.e(e);
-                    }
-                });
-                if (!abandon && onVideoTakeCallback != null) {
-                    finishRecordingVideo();
-                } else {
-                    onVideoTakeCallback = null;
-                }
-            } catch (Exception ignore) {
-            }
-        });
+        cameraControllerImp.stopVideoRecording(session, abandon);
+    }
+
+    // could be called on ChatActivity destroy
+    public void stopBackgroundThread() {
+        cameraControllerImp.stopBackgroundThread();
     }
 
     public static Size chooseOptimalSize(List<Size> choices, int width, int height, Size aspectRatio) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/camera/CameraSession.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/camera/CameraSession.java
@@ -116,7 +116,7 @@ public class CameraSession {
     }
 
     public void checkFlashMode(String mode) {
-        ArrayList<String> modes = CameraController.getInstance().availableFlashModes;
+        ArrayList<String> modes = CameraController.getInstance().getAvailableFlashModes();
         if (modes.contains(currentFlashMode)) {
             return;
         }
@@ -147,7 +147,7 @@ public class CameraSession {
     }
 
     public String getNextFlashMode() {
-        ArrayList<String> modes = CameraController.getInstance().availableFlashModes;
+        ArrayList<String> modes = CameraController.getInstance().getAvailableFlashModes();
         for (int a = 0; a < modes.size(); a++) {
             String mode = modes.get(a);
             if (mode.equals(currentFlashMode)) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/camera/ICameraController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/camera/ICameraController.java
@@ -1,0 +1,38 @@
+package org.telegram.messenger.camera;
+
+import android.graphics.SurfaceTexture;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+
+public interface ICameraController {
+
+    ArrayList<String> availableFlashModes = new ArrayList<>();
+
+    void initCamera(final Runnable onInitRunnable);
+
+    boolean isCameraInitied();
+
+    void close(final CameraSession session, final CountDownLatch countDownLatch, final Runnable beforeDestroyRunnable);
+
+    boolean takePicture(final File path, final CameraSession session, final Runnable callback);
+
+    void startPreview(final CameraSession session);
+
+    void stopPreview(final CameraSession session);
+
+    void open(final CameraSession session, final SurfaceTexture texture, final Runnable callback, final Runnable prestartCallback);
+
+    void openRound(final CameraSession session, final SurfaceTexture texture, final Runnable callback, final Runnable configureCallback);
+
+    void recordVideo(final CameraSession session, final File path, boolean mirror, final CameraController.VideoTakeCallback callback, final Runnable onVideoStartRecord);
+
+    void stopVideoRecording(final CameraSession session, final boolean abandon);
+
+    void cancelOnInitRunnable(final Runnable onInitRunnable);
+
+    void stopBackgroundThread();
+
+    ArrayList<CameraInfo> getCameras();
+}

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/InstantCameraView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/InstantCameraView.java
@@ -1244,6 +1244,10 @@ public class InstantCameraView extends FrameLayout implements NotificationCenter
             if (!recording) {
                 videoEncoder.startRecording(cameraFile, EGL14.eglGetCurrentContext());
                 recording = true;
+                if (CameraController.getInstance().isCamera2Used) {
+                    scaleX = 1.0f;
+                    scaleY = 1.0f;
+                }
                 int orientation = currentSession.getCurrentOrientation();
                 if (orientation == 90 || orientation == 270) {
                     float temp = scaleX;


### PR DESCRIPTION
Added Camera2 support in Camera2Controller class for all use cases like preview, photo capture, video capture and instant video capture.
Added an interface and a fabric class CameraController that decides which camera class to use on a given device.
The original CameraController is kept intact, except for adding the interface implementation and renaming to Camera1Controller, so added minimal changes in original code.

Tested new code on Redmi 7A, Samsung A51, Meizu, Huawei, and low end device Vertex IW.